### PR TITLE
Update Home Page with more info/details on OpenStudio components

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,8 +1,37 @@
 <div class="row">
   <main class="col-md-9">
-    <p>OpenStudio<sup>®</sup> is a cross-platform (Windows, Mac, and Linux) collection of software tools to support whole building energy modeling using EnergyPlus and advanced daylight analysis using Radiance.  OpenStudio is an open source (LGPL) project to facilitate community development, extension, and private sector adoption. </p>
+    <p>OpenStudio<sup>®</sup> is a cross-platform (Windows, Mac, and Linux) collection of software tools to support whole building energy modeling using EnergyPlus and advanced daylight analysis using Radiance.  OpenStudio is an open source project to facilitate community development, extension, and private sector adoption. </p>
 
-    <p>The graphical applications include the OpenStudio SketchUp Plug-in, OpenStudio Application, and the Parametric Analysis Tool. The SketchUp Plug-in and the Openstudio Application are maintained by the <a href="https://openstudiocoalition.org">OpenStudio Coalition</a>, which was founded to maintain and develop these graphical applications for the building energy modeling community.  The SketchUp Plug-in is an extension to Trimble’s popular SketchUp 3D modeling tool that allows users to quickly create geometry needed for EnergyPlus.  Additionally, OpenStudio supports import of gbXML and IFC for geometry creation.  The OpenStudio Application is a fully featured graphical interface to OpenStudio models including envelope, loads, schedules, and HVAC. ResultsViewer enables browsing, plotting, and comparing simulation output data, especially time series.  The Parametric Analysis Tool enables studying the impact of applying multiple combinations of OpenStudio Measures to a base model as well as export of the analysis results for EDAPT submission.</p>
+    <p><a href="http://github.com/NREL/OpenStudio">OpenStudio SDK</a> is both a Software Development Kit (SDK) and a Command Line Interface (CLI).
+    Conceptually, OpenStudio SDK provides an Application Programming Interface (API) to access the
+    EnergyPlus modeling engine. This interface provides many benefits such as a stable, version-controlled
+    interface, space typology abstractions that make it easier for end-users to model buildings, and language
+    bindings in Ruby, Python and C-Sharp to make it more accessible to users familiar with these languages.
+    The CLI is a powerful, cross-platform tool that allows users to run OpenStudio based workflows on
+    supported architectures such as Linux, Windows and Mac.</p>
+
+    <p>The graphical applications include the <a href="https://github.com/openstudiocoalition/openstudio-sketchup-plugin">OpenStudio SketchUp Plug-in</a>, <a href="https://github.com/openstudiocoalition/openstudioapplication">OpenStudio Application</a>, and the <a href="https://github.com/NREL/OpenStudio-PAT">Parametric Analysis Tool</a>. The SketchUp Plug-in and the Openstudio Application are maintained by the <a href="https://openstudiocoalition.org">OpenStudio Coalition</a>, which was founded to maintain and develop these graphical applications for the building energy modeling community.  The SketchUp Plug-in is an extension to Trimble’s popular SketchUp 3D modeling tool that allows users to quickly create geometry needed for EnergyPlus.  Additionally, OpenStudio supports import of gbXML and IFC for geometry creation.  The OpenStudio Application is a fully featured graphical interface to OpenStudio models including envelope, loads, schedules, and HVAC. ResultsViewer enables browsing, plotting, and comparing simulation output data, especially time series.  The Parametric Analysis Tool enables studying the impact of applying multiple combinations of OpenStudio Measures to a base model as well as export of the analysis results for EDAPT submission.</p>
+
+    <p>OpenStudio Measure is a scripting facility that uses Ruby (and now phase 1 support for Python in v3.5.0)
+    to automate model queries and transformations and to incrementally extend and customize the
+    OpenStudio platform. To date, hundreds of Measures have been written and posted on the Building
+    Component Library (BCL) (https://bcl.nrel.gov/), an open online database of OpenStudio related content
+    like weather files, construction and equipment specifications. These Measures perform transformations
+    that correspond to energy conservation measures—that’s the origin of the name—that range from
+    simple lighting power density reductions to complex and context sensitive daylighting transformations,
+    create custom reports, and link energy simulation to other analyses.</p>
+
+    <p><a href="https://github.com/NREL/OpenStudio-standards">OpenStudio Standards</a> is a collection of Measures and resources that automate the construction of
+    prototype building models (e.g., office, hospital, primary school) as well as the transformations
+    associated with ASHRAE Standard 90.1 Appendix G “Performance Rating Method”, a commonly
+    exercised transformation that supports code compliance, LEED certification, and utility incentive
+    calculations.</p>
+
+    <p><a href="https://github.com/NREL/OpenStudio-server">OpenStudio Server</a> allows vendors and users to combine seed models—either prototypical or specific—
+    with Measures in a large-scale computing environment to specify and organize large scale analyses such
+    as uncertainty analysis, model calibration, design optimization, or stock level measure analysis, all via
+    the OpenStudio Analysis Framework (OSAF) quickly and systematically. The transparency of the
+    OpenStudio platform is requisite for applications that support taxpayer and ratepayer funded programs.</p>
 
     <p>OpenStudio allows building researchers and software developers to quickly get started through its multiple entry levels, including access through C++, Ruby, Python and C#. Users can leverage the Ruby interface to create OpenStudio Measures that can be easily shared and applied to OpenStudio Models.</p>
 

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,37 +1,16 @@
 <div class="row">
   <main class="col-md-9">
-    <p>OpenStudio<sup>®</sup> is a cross-platform (Windows, Mac, and Linux) collection of software tools to support whole building energy modeling using EnergyPlus and advanced daylight analysis using Radiance.  OpenStudio is an open source project to facilitate community development, extension, and private sector adoption. </p>
+    <p>OpenStudio<sup>®</sup> is a cross-platform (Windows, Mac, and Linux) collection of software tools to support whole building energy modeling using EnergyPlus and advanced daylight analysis using Radiance. OpenStudio is an open source project to facilitate community development, extension, and private sector adoption.</p>
 
-    <p><a href="http://github.com/NREL/OpenStudio">OpenStudio SDK</a> is both a Software Development Kit (SDK) and a Command Line Interface (CLI).
-    Conceptually, OpenStudio SDK provides an Application Programming Interface (API) to access the
-    EnergyPlus modeling engine. This interface provides many benefits such as a stable, version-controlled
-    interface, space typology abstractions that make it easier for end-users to model buildings, and language
-    bindings in Ruby, Python and C-Sharp to make it more accessible to users familiar with these languages.
-    The CLI is a powerful, cross-platform tool that allows users to run OpenStudio based workflows on
-    supported architectures such as Linux, Windows and Mac.</p>
+    <p><a href="https://github.com/NREL/OpenStudio">OpenStudio SDK</a> is both a Software Development Kit (SDK) and a Command Line Interface (CLI). Conceptually, OpenStudio SDK provides an Application Programming Interface (API) to access the EnergyPlus modeling engine. This interface provides many benefits such as a stable, version-controlled interface, space typology abstractions that make it easier for end-users to model buildings, and language bindings in Ruby, Python and C-Sharp to make it more accessible to users familiar with these languages. The CLI is a powerful, cross-platform tool that allows users to run OpenStudio based workflows on supported architectures such as Linux, Windows and Mac.</p>
 
-    <p>The graphical applications include the <a href="https://github.com/openstudiocoalition/openstudio-sketchup-plugin">OpenStudio SketchUp Plug-in</a>, <a href="https://github.com/openstudiocoalition/openstudioapplication">OpenStudio Application</a>, and the <a href="https://github.com/NREL/OpenStudio-PAT">Parametric Analysis Tool</a>. The SketchUp Plug-in and the Openstudio Application are maintained by the <a href="https://openstudiocoalition.org">OpenStudio Coalition</a>, which was founded to maintain and develop these graphical applications for the building energy modeling community.  The SketchUp Plug-in is an extension to Trimble’s popular SketchUp 3D modeling tool that allows users to quickly create geometry needed for EnergyPlus.  Additionally, OpenStudio supports import of gbXML and IFC for geometry creation.  The OpenStudio Application is a fully featured graphical interface to OpenStudio models including envelope, loads, schedules, and HVAC. ResultsViewer enables browsing, plotting, and comparing simulation output data, especially time series.  The Parametric Analysis Tool enables studying the impact of applying multiple combinations of OpenStudio Measures to a base model as well as export of the analysis results for EDAPT submission.</p>
+    <p>The graphical applications include the <a href="https://github.com/openstudiocoalition/openstudio-sketchup-plugin">OpenStudio SketchUp Plug-in</a>, <a href="https://github.com/openstudiocoalition/openstudioapplication">OpenStudio Application</a>, and the <a href="https://github.com/NREL/OpenStudio-PAT">Parametric Analysis Tool</a>. The SketchUp Plug-in and the Openstudio Application are maintained by the <a href="https://openstudiocoalition.org">OpenStudio Coalition</a>, which was founded to maintain and develop these graphical applications for the building energy modeling community. The SketchUp Plug-in is an extension to Trimble’s popular SketchUp 3D modeling tool that allows users to quickly create geometry needed for EnergyPlus. Additionally, OpenStudio supports import of gbXML and IFC for geometry creation. The OpenStudio Application is a fully featured graphical interface to OpenStudio models including envelope, loads, schedules, and HVAC. ResultsViewer enables browsing, plotting, and comparing simulation output data, especially time series. The Parametric Analysis Tool enables studying the impact of applying multiple combinations of OpenStudio Measures to a base model as well as export of the analysis results for EDAPT submission.</p>
 
-    <p>OpenStudio Measure is a scripting facility that uses Ruby (and now phase 1 support for Python in v3.5.0)
-    to automate model queries and transformations and to incrementally extend and customize the
-    OpenStudio platform. To date, hundreds of Measures have been written and posted on the Building
-    Component Library (BCL) (https://bcl.nrel.gov/), an open online database of OpenStudio related content
-    like weather files, construction and equipment specifications. These Measures perform transformations
-    that correspond to energy conservation measures—that’s the origin of the name—that range from
-    simple lighting power density reductions to complex and context sensitive daylighting transformations,
-    create custom reports, and link energy simulation to other analyses.</p>
+    <p>OpenStudio Measure is a scripting facility that uses Ruby (and now phase 1 support for Python in v3.5.0) to automate model queries and transformations and to incrementally extend and customize the OpenStudio platform. To date, hundreds of Measures have been written and posted on the Building Component Library (BCL) (https://bcl.nrel.gov/), an open online database of OpenStudio related content like weather files, construction and equipment specifications. These Measures perform transformations that correspond to energy conservation measures—that’s the origin of the name—that range from simple lighting power density reductions to complex and context sensitive daylighting transformations, create custom reports, and link energy simulation to other analyses.</p>
 
-    <p><a href="https://github.com/NREL/OpenStudio-standards">OpenStudio Standards</a> is a collection of Measures and resources that automate the construction of
-    prototype building models (e.g., office, hospital, primary school) as well as the transformations
-    associated with ASHRAE Standard 90.1 Appendix G “Performance Rating Method”, a commonly
-    exercised transformation that supports code compliance, LEED certification, and utility incentive
-    calculations.</p>
+    <p><a href="https://github.com/NREL/OpenStudio-standards">OpenStudio Standards</a> is a collection of Measures and resources that automate the construction of prototype building models (e.g., office, hospital, primary school) as well as the transformations associated with ASHRAE Standard 90.1 Appendix G “Performance Rating Method”, a commonly exercised transformation that supports code compliance, LEED certification, and utility incentive calculations.</p>
 
-    <p><a href="https://github.com/NREL/OpenStudio-server">OpenStudio Server</a> allows vendors and users to combine seed models—either prototypical or specific—
-    with Measures in a large-scale computing environment to specify and organize large scale analyses such
-    as uncertainty analysis, model calibration, design optimization, or stock level measure analysis, all via
-    the OpenStudio Analysis Framework (OSAF) quickly and systematically. The transparency of the
-    OpenStudio platform is requisite for applications that support taxpayer and ratepayer funded programs.</p>
+    <p><a href="https://github.com/NREL/OpenStudio-server">OpenStudio Server</a> allows vendors and users to combine seed models—either prototypical or specific— with Measures in a large-scale computing environment to specify and organize large scale analyses such as uncertainty analysis, model calibration, design optimization, or stock level measure analysis, all via the OpenStudio Analysis Framework (OSAF) quickly and systematically. The transparency of the OpenStudio platform is requisite for applications that support taxpayer and ratepayer funded programs.</p>
 
     <p>OpenStudio allows building researchers and software developers to quickly get started through its multiple entry levels, including access through C++, Ruby, Python and C#. Users can leverage the Ruby interface to create OpenStudio Measures that can be easily shared and applied to OpenStudio Models.</p>
 


### PR DESCRIPTION
Currently, the main landing page is just a small paragraph about OpenStudio. This expands and provided more details on the various components (SDK, App, Measures, Sever, etc) with links to each repo.  